### PR TITLE
Create bin/ to avoid unexpected cp behavior during make.

### DIFF
--- a/src/unix.mk
+++ b/src/unix.mk
@@ -176,6 +176,7 @@ endif
 	
 ##############
 $(COMPONENTS): $(THOBJS) $(OBJS)
+	@ mkdir -p $(BIN)
 	@ printf '\n-------------------\n'
 	@ echo 'Building $@'
 	@ echo '-------------------'

--- a/src/unix.mk
+++ b/src/unix.mk
@@ -206,7 +206,7 @@ install: check_uid
 	@ $(CP) $(BIN)/libITG$(SOSUFFIX) "$(PREFIX)/lib"
 	@ echo 'done'
 	@ printf '\n----------------------------------------------------------\n'
-	@ echo 'D-ITG installed in $(BIN)'
+	@ echo 'D-ITG installed in $(PREFIX)/bin'
 	
 ##########
 uninstall: check_uid check_ditg


### PR DESCRIPTION
OS: Ubuntu 20.04.6 LTS
make: 4.2.1
g++: 9.4.0

Avoid the issue during the make "-lITG couldn't be found" as there's no bin/ at first and thus cp commands create a binary bin under the root.