### PR TITLE
Fix errors encountered when running `make`

### DIFF
--- a/src/ITGDec/ITGDecod.cpp
+++ b/src/ITGDec/ITGDecod.cpp
@@ -129,7 +129,7 @@ ofstream outbin;
 ifstream sendlog;
 FILE *intxt;
 FILE *outtxt;
-int size, flagfilter, flagwinlin;
+int thissize, flagfilter, flagwinlin;
 unsigned int flownum;
 double msbitrate, msjitter, mspktloss, msdelay, mscombinedstats, secfirstline_gl;
 gestioneFileLog memFile[MaxNumFlow];
@@ -557,10 +557,10 @@ int main(int argc, char *argv[])
 		}
 	}
 	
-	size = 1;
-	while (size > 0) {
+	thissize = 1;
+	while (thissize > 0) {
 		infos = readline(&inbin, intxt, logintype);
-		if (size > 0) { 
+		if (thissize > 0) {
 			mark();
 			if (flagreconstruct) {
 				struct info *send_info = found((*infos).flowId, (*infos).srcAddr, (*infos).destAddr, (*infos).srcPort,
@@ -968,7 +968,7 @@ struct info *readline(ifstream *fbin, FILE *ftxt, int filetype)
 	if (filetype == 0) {
 		
 		
-		size = fread(infos_loc, sizeof(struct info), 1, ftxt); 
+		thissize = fread(infos_loc, sizeof(struct info), 1, ftxt);
 		
 		
 		
@@ -999,12 +999,12 @@ struct info *readline(ifstream *fbin, FILE *ftxt, int filetype)
 			fscanf(ftxt, "Size>%5u\n", &(*infos_loc).size);
 			if ((*infos_loc).flowId == 0) {
 				printf("\n Error reading input file\n");
-				size = 0;
+				thissize = 0;
 			} else {
-				size = 1;
+				thissize = 1;
 			}
 		} else
-			size = 0;
+			thissize = 0;
 	}
 	return infos_loc;
 }
@@ -1310,9 +1310,9 @@ void elabsplit(int flagbit, int flagjit, int flagdel, int flagpkt)
 				PRINTD(1,"Prima di leggere le info dal file %s con puntantore %p\n",
 					memFile[i].FileName, inputfilec);
 
-				size = fread(infos, sizeof(struct info), 1, inputfilec); 
+				thissize = fread(infos, sizeof(struct info), 1, inputfilec);
 				PRINTD(1,"Info lette dal file %s\n", memFile[i].FileName);
-				if (size == 0) {
+				if (thissize == 0) {
 					if (flagbit)
 						fprintf(outfilebit, "%lf %lf\n", intclosedbit * (double) msbitrate / 1000, tempbitrate * 8
 							/ msbitrate);

--- a/src/ITGSend/ITGSend.cpp
+++ b/src/ITGSend/ITGSend.cpp
@@ -1257,7 +1257,7 @@ void *flowParser(void *param)
 				argc -= 3;
 				break;
 			case 'N':
-				if ((argc < 3) || (argv[h + 2] <= 0))	
+				if ((argc < 3) || (strtod(argv[h + 2], NULL) <= 0))
 					ReportErrorAndExit("Protocol Parser",
 					    "Invalid pkts per sec", programName, id);
 				flows[id].IntArrivDistro = pdNormal;
@@ -1392,7 +1392,7 @@ void *flowParser(void *param)
 				argc -= 3;
 				break;
 			case 'n':
-				if ((argc < 3) || (argv[h + 2] <= 0))	
+				if ((argc < 3) || (strtod(argv[h + 2], NULL) <= 0))
 					ReportErrorAndExit("Protocol Parser", "Invalid pkt size",
 					    programName, id);
 				delete flows[id].PktSize;

--- a/src/ITGSend/traffic.cpp
+++ b/src/ITGSend/traffic.cpp
@@ -412,7 +412,7 @@ void burstyParser(int &h, char *argv[], int &argc, unsigned int flowId, SumRando
 			argc -= 3;
 			break;
 		case 'N':
-			if ((argc < 5) || (argv[h + 2] <= 0))	
+			if ((argc < 5) || (strtod(argv[h + 2], NULL) <= 0))
 				ReportErrorAndExit("Protocol Parser",
 					"Invalid settings for the On/Off periods", programName, flowId);
 			b = strtod(argv[h + 1], NULL); 	
@@ -538,7 +538,7 @@ void burstyParser(int &h, char *argv[], int &argc, unsigned int flowId, SumRando
 			argc -= 3;
 			break;
 		case 'N':
-			if ((argc < 3) || (argv[h + 2] <= 0))	
+			if ((argc < 3) || (strtod(argv[h + 2], NULL) <= 0))
 				ReportErrorAndExit("Protocol Parser",
 					"Invalid settings for the Off/Off periods", programName, flowId);
 			b = strtod(argv[h + 1], NULL); 	


### PR DESCRIPTION
OS version: Ubuntu 22.04.2 LTS
make: GNU Make 4.3
g++: 11.4.0

This PR fixes the errors that came up while running `make` in /src, presumably due to newer version of C++.